### PR TITLE
feat(backend): Mehrere Keywords in der Arbeitsagentur-API abfragen

### DIFF
--- a/backend/server.py
+++ b/backend/server.py
@@ -42,7 +42,7 @@ def jobsuchen():
         keywords = data.get('keywords', []) # Holt die Keywords aus den Daten, Standard ist eine leere Liste
         location = data.get('location', '') # Holt den Standort aus den Daten, Standard ist ein leerer String
         radius = int(data.get('radius', '30')) # Holt den Radius aus den Daten, Standard ist 30 (in km)
-
+  
         print("Scraping gestartet mit:", keywords, location, radius) 
         new_jobs_stepstone = []
         new_jobs_arbeitsagentur = crawl_arbeitsagentur(keywords, location, radius)


### PR DESCRIPTION
✨ Feature: Mehrere Keywords bei Jobsuche möglich

Der Crawler für die Arbeitsagentur-API wurde so erweitert, dass jetzt mehrere Suchbegriffe („Keywords“) nacheinander abgefragt und die Ergebnisse gesammelt in MongoDB gespeichert werden.

Zusätzlich wurde sichergestellt, dass auch bei leerem Suchfeld (kein Keyword) passende Jobs im Umkreis angezeigt werden.

🔧 Änderungen:
- Neue Schleife über alle angegebenen Keywords
- Für jedes Keyword erfolgt eine eigene API-Anfrage
- Ergebnisse werden gesammelt und gespeichert
- Ausgabe optimiert und Exceptions sauber behandelt

 🧪 Testhinweise:
- Mehrere Suchbegriffe eingeben, z. B. `frontend`, `webdeveloper`
- Auch testen mit leerem Feld (→ es werden allgemeine Jobs geladen)
- Ergebnisse sollten korrekt in der MongoDB erscheinen

Closes #28
