### PR TITLE
fix(frontend/backend): Bookmark-Update mit flexibler ID repariert

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -33,15 +33,18 @@ function App() {
 
   const handleBookmarkChange = (e, job) => {
     const updatedBookmarkStatus = e.target.checked;
+    
     const updatedJobs = jobs.map((j) =>
-      j.link === job.link ? { ...j, bookmark: updatedBookmarkStatus } : j
+      j._id === job._id ? { ...j, bookmark: updatedBookmarkStatus } : j
     );
     setJobs(updatedJobs);
   
     fetch("http://localhost:3050/update_bookmark", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ _id: job._id, bookmark: updatedBookmarkStatus }),
+      body: JSON.stringify({ 
+        _id: job._id, 
+        bookmark: updatedBookmarkStatus }),
     })
       .then((res) => res.json())
       .then((data) => {


### PR DESCRIPTION
 Änderungen:

- Im Frontend wurde die Bookmark-Funktion korrekt an das `job._id`-Feld angebunden
- Im Backend (Flask) wird nun flexibel mit ObjectId oder HashId gearbeitet
- Das Update des Bookmark-Status funktioniert jetzt zuverlässig mit beiden ID-Typen

Warum diese Änderung?

- Zuvor kam es bei Arbeitsagentur-Jobs (mit HashId) zu Fehlern im Lesezeichen-Update (404)
- Jetzt wird automatisch erkannt, ob eine MongoDB-ObjectId oder eine einfache Zeichenkette übergeben wurde

Nächste Schritte:
- Verlinkung des „Details“-Buttons mit der `stellenbeschreibung`-URL vorbereiten
