### PR TITLE
Feature/e2e testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,9 @@ node_modules
 dist
 dist-ssr
 *.local
+playwright-report
+test-results
+blob-report
 
 # Editor directories and files
 .vscode/*

--- a/backend/server.py
+++ b/backend/server.py
@@ -55,7 +55,7 @@ except Exception as e:
 
 
 app = Flask(__name__)  # Erstellt eine Flask-Instanz
-FRONTEND_ORIGIN = os.getenv("PUBLIC_APP_URL", "http://localhost:5173")
+FRONTEND_ORIGIN = os.getenv("PUBLIC_APP_URL")
 CORS(app, resources={r"/*": {"origins": [FRONTEND_ORIGIN]}})
 Talisman(app, content_security_policy=None, force_https=False, strict_transport_security=False)  # Aktiviert Sicherheits-Header
 

--- a/frontend/TESTING-E2E.md
+++ b/frontend/TESTING-E2E.md
@@ -1,0 +1,37 @@
+# End-to-End-Tests mit Playwright
+
+Dieses Frontend nutzt [Playwright](https://playwright.dev) für browserbasierte E2E-Tests. Die Konfiguration startet den Vite-Dev-Server automatisch und prüft den Landing-Flow, ohne dass ein Backend laufen muss.
+
+## Installation
+1. Stelle sicher, dass `node` und `npm` installiert sind.
+2. Browser-Binärdateien installieren (einmalig):
+   ```bash
+   npx playwright install --with-deps
+   ```
+   Falls npm-Registry-Zugriffe durch einen Proxy blockiert werden, entferne die Proxy-Variablen temporär oder passe sie an.
+
+3. Abhängigkeiten aktualisieren:
+   ```bash
+   npm install
+   ```
+
+## Ausführen
+Standardlauf (headless):
+```bash
+npm run test:e2e
+```
+
+Nützliche Varianten:
+- Headed (zum Debuggen): `npm run test:e2e:headed`
+- Nur Report anzeigen (ohne erneuten Testlauf): `npm run test:e2e:report`
+- Codegen-Recorder: `npm run test:e2e:codegen`
+
+Die `playwright.config.js` startet automatisch `npm run dev -- --host --port 5173`. Setze `E2E_BASE_URL`, wenn du einen bereits laufenden Server wiederverwenden möchtest, oder `E2E_PORT`, um den Port zu ändern.
+
+## Testaufbau
+Aktuelle Tests liegen unter `tests/e2e/` und prüfen, dass die Landing-Page die primären CTA-Links und Feature-Blöcke rendert. Weitere Flows können analog hinzugefügt werden, z. B. Login oder Jobsuche mit API-Mocks.
+
+### Tipps für neue Tests
+- Greife über ARIA-Rollen (`getByRole`) und sichtbare Texte zu, um robuste Selektoren zu erhalten.
+- Verwende `test.step` und Screenshots/Traces (`trace: 'on-first-retry'`) für bessere Fehlersuche.
+- Für API-Mocks kann `page.route` genutzt werden, um Antworten für `/jobsuchen` oder Auth-Calls zu stürpen.

--- a/frontend/TESTING-E2E.md
+++ b/frontend/TESTING-E2E.md
@@ -1,25 +1,25 @@
 # End-to-End-Tests mit Playwright
 
-Dieses Frontend nutzt [Playwright](https://playwright.dev) für browserbasierte E2E-Tests. Die Konfiguration startet den Vite-Dev-Server automatisch und prüft den Landing-Flow, ohne dass ein Backend laufen muss.
+Dieses Frontend nutzt [Playwright](https://playwright.dev) fuer browserbasierte E2E-Tests. Die Konfiguration startet den Vite-Dev-Server automatisch und prueft den Landing-Flow, ohne dass ein Backend laufen muss.
 
 ## Installation
 
 1. Stelle sicher, dass `node` und `npm` installiert sind.
-2. Browser-Binärdateien installieren (einmalig):
+2. Browser-Binaerdateien installieren (einmalig):
 
    ```bash
    npx playwright install --with-deps
    ```
 
-   Falls npm-Registry-Zugriffe durch einen Proxy blockiert werden, entferne die Proxy-Variablen temporär oder passe sie an.
+   Falls npm-Registry-Zugriffe durch einen Proxy blockiert werden, entferne die Proxy-Variablen temporaer oder passe sie an.
 
-3. Abhängigkeiten aktualisieren:
+3. Abhaengigkeiten aktualisieren:
 
    ```bash
    npm install
    ```
 
-## Ausführen
+## Ausfuehren
 
 Standardlauf (headless):
 
@@ -27,20 +27,36 @@ Standardlauf (headless):
 npm run test:e2e
 ```
 
-Nützliche Varianten:
+Nuetzliche Varianten:
 
 - Headed (zum Debuggen): `npm run test:e2e:headed`
 - Nur Report anzeigen (ohne erneuten Testlauf): `npm run test:e2e:report`
 - Codegen-Recorder: `npm run test:e2e:codegen`
 
-Die `playwright.config.js` startet automatisch `npm run dev -- --host --port 5173`. Setze `E2E_BASE_URL`, wenn du einen bereits laufenden Server wiederverwenden möchtest, oder `E2E_PORT`, um den Port zu ändern.
+Die `playwright.config.js` startet automatisch `npm run dev -- --host --port 5173`. Setze `E2E_BASE_URL`, wenn du einen bereits laufenden Server wiederverwenden moechtest, oder `E2E_PORT`, um den Port zu aendern.
 
 ## Testaufbau
 
-Aktuelle Tests liegen unter `tests/e2e/` und prüfen, dass die Landing-Page die primären CTA-Links und Feature-Blöcke rendert. Weitere Flows können analog hinzugefügt werden, z. B. Login oder Jobsuche mit API-Mocks.
+Aktuelle Tests liegen unter `tests/e2e/` und pruefen, dass die Landing-Page die primaeren CTA-Links und Feature-Bloecke rendert. Weitere Flows koennen analog hinzugefuegt werden, z. B. Login oder Jobsuche.
 
-### Tipps für neue Tests
+Aktuelle Specs (kurz):
 
-- Greife über ARIA-Rollen (`getByRole`) und sichtbare Texte zu, um robuste Selektoren zu erhalten.
-- Verwende `test.step` und Screenshots/Traces (`trace: 'on-first-retry'`) für bessere Fehlersuche.
-- Für API-Mocks kann `page.route` genutzt werden, um Antworten für `/jobsuchen` oder Auth-Calls zu stürpen.
+- `landing.spec.js`: Smoke fuer Landing (CTAs sichtbar + Hrefs, drei Feature-Headings).
+- `navigation.spec.js`: Sidebar-Navigation zwischen App-Routen, Logo-Link zur Landing Page.
+- `auth.spec.js`: Login Erfolg/Fehler (mit Mocks) und Registrierung.
+- `search.spec.js`: Jobsuche (Request-Body, Ergebnisliste) und Bookmark-Toggle (Mock).
+- `forms.spec.js`: Formulare/Validierung (Jobsuche: Pflichtfeld/Loading; Reset-Links/Passwort-Reset: Erfolg/Fehler).
+
+### So liest du die Playwright-Tests (Kurzfassung)
+
+- Selektoren: `getByRole` + sichtbarer Text/Label bevorzugen; `getByLabel` fuer Formfelder. `data-testid` nur, wenn ARIA/Labels nicht reichen.
+- Erwartungen: `expect(...).toBeVisible()` fuer Sichtbarkeit, `toHaveURL`/`toHaveAttribute` fuer Navigation/Links.
+- Mocks: `page.route("**/api/...", route => route.fulfill({ status: 200, body: "[]" }))` verhindert echte Backend-Calls.
+- Auth-Stubs: `page.addInitScript(() => localStorage.setItem("access", "..."))` setzt Tokens vor dem ersten Request (siehe `navigation.spec.js`).
+- Kommentare: Kurz notieren, warum der Check existiert (Ziel), nicht was Syntax macht.
+
+### Tipps fuer neue Tests
+
+- Greife ueber ARIA-Rollen (`getByRole`) und sichtbare Texte zu, um robuste Selektoren zu erhalten.
+- Verwende `test.step` und Screenshots/Traces (`trace: 'on-first-retry'`) fuer bessere Fehlersuche.
+- Fuer API-Mocks kann `page.route` genutzt werden, um Antworten fuer `/jobsuchen` oder Auth-Calls zu stubben.

--- a/frontend/TESTING-E2E.md
+++ b/frontend/TESTING-E2E.md
@@ -3,25 +3,32 @@
 Dieses Frontend nutzt [Playwright](https://playwright.dev) für browserbasierte E2E-Tests. Die Konfiguration startet den Vite-Dev-Server automatisch und prüft den Landing-Flow, ohne dass ein Backend laufen muss.
 
 ## Installation
+
 1. Stelle sicher, dass `node` und `npm` installiert sind.
 2. Browser-Binärdateien installieren (einmalig):
+
    ```bash
    npx playwright install --with-deps
    ```
+
    Falls npm-Registry-Zugriffe durch einen Proxy blockiert werden, entferne die Proxy-Variablen temporär oder passe sie an.
 
 3. Abhängigkeiten aktualisieren:
+
    ```bash
    npm install
    ```
 
 ## Ausführen
+
 Standardlauf (headless):
+
 ```bash
 npm run test:e2e
 ```
 
 Nützliche Varianten:
+
 - Headed (zum Debuggen): `npm run test:e2e:headed`
 - Nur Report anzeigen (ohne erneuten Testlauf): `npm run test:e2e:report`
 - Codegen-Recorder: `npm run test:e2e:codegen`
@@ -29,9 +36,11 @@ Nützliche Varianten:
 Die `playwright.config.js` startet automatisch `npm run dev -- --host --port 5173`. Setze `E2E_BASE_URL`, wenn du einen bereits laufenden Server wiederverwenden möchtest, oder `E2E_PORT`, um den Port zu ändern.
 
 ## Testaufbau
+
 Aktuelle Tests liegen unter `tests/e2e/` und prüfen, dass die Landing-Page die primären CTA-Links und Feature-Blöcke rendert. Weitere Flows können analog hinzugefügt werden, z. B. Login oder Jobsuche mit API-Mocks.
 
 ### Tipps für neue Tests
+
 - Greife über ARIA-Rollen (`getByRole`) und sichtbare Texte zu, um robuste Selektoren zu erhalten.
 - Verwende `test.step` und Screenshots/Traces (`trace: 'on-first-retry'`) für bessere Fehlersuche.
 - Für API-Mocks kann `page.route` genutzt werden, um Antworten für `/jobsuchen` oder Auth-Calls zu stürpen.

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -14,6 +14,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.21.0",
+        "@playwright/test": "^1.50.1",
         "@tailwindcss/forms": "^0.5.10",
         "@tailwindcss/typography": "^0.5.16",
         "@tailwindcss/vite": "^4.1.12",
@@ -1089,6 +1090,22 @@
       },
       "funding": {
         "url": "https://opencollective.com/pkgr"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.57.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.57.0.tgz",
+      "integrity": "sha512-6TyEnHgd6SArQO8UO2OMTxshln3QMWBtPGrOCgs3wVEmQmwyuNtB10IZMfmYDE0riwNR1cu4q+pPcxMVtaG3TA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.57.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@rolldown/pluginutils": {
@@ -4214,6 +4231,53 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.57.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.57.0.tgz",
+      "integrity": "sha512-ilYQj1s8sr2ppEJ2YVadYBN0Mb3mdo9J0wQ+UuDhzYqURwSoW4n1Xs5vs7ORwgDGmyEh33tRMeS8KhdkMoLXQw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.57.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.57.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.57.0.tgz",
+      "integrity": "sha512-agTcKlMw/mjBWOnD6kFZttAAGHgi/Nw0CZ2o6JqWSbMlI219lAFLZZCyqByTsvVAJq5XA5H8cA6PrvBRpBWEuQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/postcss": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,7 +12,11 @@
     "format:check": "prettier --check .",
     "format:fix": "prettier --write .",
     "lint:md": "markdownlint-cli2 '../README.md' '../backend/README.md' './README.md'",
-    "format:md": "markdownlint-cli2 '../README.md' '../backend/README.md' './README.md' --fix"
+    "format:md": "markdownlint-cli2 '../README.md' '../backend/README.md' './README.md' --fix",
+    "test:e2e": "playwright test",
+    "test:e2e:headed": "playwright test --headed",
+    "test:e2e:report": "playwright show-report",
+    "test:e2e:codegen": "playwright codegen http://localhost:5173"
   },
   "dependencies": {
     "react": "^19.1.1",
@@ -27,6 +31,7 @@
     "@types/react": "^19.1.1",
     "@types/react-dom": "^19.1.1",
     "@vitejs/plugin-react": "^4.3.4",
+    "@playwright/test": "^1.50.1",
     "eslint": "^9.29.0",
     "esbuild": "0.25.9",
     "eslint-config-prettier": "^10.1.8",

--- a/frontend/playwright.config.js
+++ b/frontend/playwright.config.js
@@ -1,0 +1,37 @@
+import { defineConfig, devices } from '@playwright/test';
+
+const PORT = process.env.E2E_PORT || 5173;
+const baseURL = process.env.E2E_BASE_URL || `http://localhost:${PORT}`;
+
+export default defineConfig({
+  testDir: './tests/e2e',
+  fullyParallel: true,
+  timeout: 60000,
+  expect: {
+    timeout: 10000,
+  },
+  retries: process.env.CI ? 2 : 0,
+  reporter: [
+    ['list'],
+    ['html', { open: 'never' }],
+  ],
+  use: {
+    baseURL,
+    trace: 'on-first-retry',
+    screenshot: 'only-on-failure',
+    video: 'retain-on-failure',
+  },
+  webServer: {
+    command: `npm run dev -- --host --port ${PORT}`,
+    url: baseURL,
+    reuseExistingServer: !process.env.CI,
+    stdout: 'pipe',
+    timeout: 120000,
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+});

--- a/frontend/tests/e2e/auth.spec.js
+++ b/frontend/tests/e2e/auth.spec.js
@@ -1,0 +1,67 @@
+import { test, expect } from "@playwright/test";
+
+// Auth-Flows: Login (Erfolg/Fehler) und Registrierung, jeweils mit API-Mocks.
+test.describe("Auth flows", () => {
+  test("login success navigates to /app", async ({ page }) => {
+    let loginBody = null;
+
+    await page.route("**/auth/login", (route) => {
+      loginBody = route.request().postDataJSON();
+      route.fulfill({
+        status: 200,
+        body: JSON.stringify({ access: "token", refresh: "refresh-token" }),
+      });
+    });
+    await page.route("**/jobsuchen", (route) =>
+      route.fulfill({ status: 200, body: "[]" }),
+    );
+
+    await page.goto("/login");
+    await page.getByPlaceholder("E-Mail").fill("user@example.com");
+    await page.getByPlaceholder("Passwort").fill("secret123");
+    await page.getByRole("button", { name: /einloggen/i }).click();
+
+    await expect(page).toHaveURL(/\/app$/);
+    expect(loginBody).toEqual({
+      email: "user@example.com",
+      password: "secret123",
+    });
+  });
+
+  test("login error shows message and stays on /login", async ({ page }) => {
+    await page.route("**/auth/login", (route) =>
+      route.fulfill({
+        status: 401,
+        body: JSON.stringify({ error: "Invalid credentials" }),
+      }),
+    );
+
+    await page.goto("/login");
+    await page.getByPlaceholder("E-Mail").fill("user@example.com");
+    await page.getByPlaceholder("Passwort").fill("wrong");
+    await page.getByRole("button", { name: /einloggen/i }).click();
+
+    await expect(page).toHaveURL(/\/login$/);
+    await expect(page.getByText(/invalid|fehlgeschlagen/i)).toBeVisible();
+  });
+
+  test("register success shows confirmation", async ({ page }) => {
+    let registerBody = null;
+
+    await page.route("**/auth/register", (route) => {
+      registerBody = route.request().postDataJSON();
+      route.fulfill({ status: 200, body: JSON.stringify({ ok: true }) });
+    });
+
+    await page.goto("/register");
+    await page.getByPlaceholder("E-Mail").fill("new@example.com");
+    await page.getByPlaceholder("Passwort").fill("secret123");
+    await page.getByRole("button", { name: /konto anlegen/i }).click();
+
+    await expect(page.getByText(/registriert/i)).toBeVisible();
+    expect(registerBody).toEqual({
+      email: "new@example.com",
+      password: "secret123",
+    });
+  });
+});

--- a/frontend/tests/e2e/forms.spec.js
+++ b/frontend/tests/e2e/forms.spec.js
@@ -1,0 +1,195 @@
+import { test, expect } from "@playwright/test";
+
+// Dauerhaftes Fake-JWT mit gueltigem exp in ferner Zukunft,
+// damit initAutoLogout nicht die Tokens loescht.
+const TEST_ACCESS =
+  "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiIjo0MTAyNDQ0ODAwfQ.dummy";
+
+test.use({
+  storageState: {
+    origins: [
+      {
+        origin: "http://localhost:5173",
+        localStorage: [
+          { name: "access", value: TEST_ACCESS },
+          { name: "refresh", value: "e2e-refresh" },
+          { name: "auth_email", value: "e2e@example.com" },
+        ],
+      },
+      {
+        origin: "http://127.0.0.1:5173",
+        localStorage: [
+          { name: "access", value: TEST_ACCESS },
+          { name: "refresh", value: "e2e-refresh" },
+          { name: "auth_email", value: "e2e@example.com" },
+        ],
+      },
+    ],
+  },
+});
+
+// Formulare: Pflichtfelder, Loading, Erfolg/Fehler-Messages (alles gemockt).
+test.describe("Formulare & Validierung", () => {
+  test.beforeEach(async ({ page }) => {
+    const ctx = page.context();
+
+    // Routen VOR erstem goto mocken, damit initiale Requests abgefangen werden
+    await ctx.route("**/auth/login", (route) =>
+      route.fulfill({
+        status: 200,
+        headers: {
+          "access-control-allow-origin": "*",
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({ access: TEST_ACCESS, refresh: "e2e-refresh" }),
+      }),
+    );
+
+    await ctx.route("**/jobsuchen", (route) =>
+      route.fulfill({
+        status: 200,
+        headers: {
+          "access-control-allow-origin": "*",
+          "content-type": "application/json",
+        },
+        body: "[]",
+      }),
+    );
+    await ctx.route("**/auth/request-password-reset", (route) =>
+      route.fulfill({
+        status: 200,
+        headers: {
+          "access-control-allow-origin": "*",
+          "content-type": "application/json",
+        },
+        body: "{}",
+      }),
+    );
+    await ctx.route("**/auth/reset-password", (route) =>
+      route.fulfill({
+        status: 200,
+        headers: {
+          "access-control-allow-origin": "*",
+          "content-type": "application/json",
+        },
+        body: "{}",
+      }),
+    );
+
+    // Token direkt setzen, dann App laden (kein UI-Login nötig)
+    await page.addInitScript(({ token }) => {
+      localStorage.setItem("access", token);
+      localStorage.setItem("refresh", "e2e-refresh");
+      localStorage.setItem("auth_email", "e2e@example.com");
+    }, { token: TEST_ACCESS });
+
+    await page.goto("/app");
+  });
+
+  test("jobsuche erfordert Standort; ohne Standort kein Request", async ({
+    page,
+  }) => {
+    let called = false;
+    await page.route("**/jobsuchen", (route) => {
+      called = true;
+      route.fulfill({
+        status: 200,
+        headers: {
+          "access-control-allow-origin": "*",
+          "content-type": "application/json",
+        },
+        body: "[]",
+      });
+    });
+
+    await page.goto("/app");
+    await page.getByRole("button", { name: /jobs finden/i }).click();
+    await page.waitForTimeout(200); // kurze Pause, falls Submission doch laeuft
+    expect(called).toBe(false);
+  });
+
+  test("jobsuche zeigt Loading und rendert Ergebnisse nach Response", async ({
+    page,
+  }) => {
+    await page.route("**/jobsuchen", async (route) => {
+      await new Promise((r) => setTimeout(r, 300)); // Loading sichtbar lassen
+      route.fulfill({
+        status: 200,
+        headers: {
+          "access-control-allow-origin": "*",
+          "content-type": "application/json",
+        },
+        body: JSON.stringify([
+          {
+            _id: "job-1",
+            title: "Backend Developer",
+            company: "Acme",
+            link: "https://example.com/job-1",
+            bookmark: false,
+          },
+        ]),
+      });
+    });
+
+    await page.goto("/app");
+    await page.getByPlaceholder("Neuen Suchbegriff eingeben").fill("API");
+    await page.getByRole("button", { name: /\+ Suchbegriff/i }).click();
+    await page.getByPlaceholder("Standort eingeben").fill("Hamburg");
+    await page.getByRole("button", { name: /jobs finden/i }).click();
+
+    // Loading-Indicator sichtbar, waehrend Response laeuft
+    await expect(page.getByText(/ldt/i)).toBeVisible();
+
+    // Nach Response: Ergebnis erscheint, Loading verschwindet
+    await expect(page.getByText("Backend Developer")).toBeVisible();
+    await expect(page.getByText(/ldt/i)).not.toBeVisible();
+  });
+
+  test("passwort-reset-link anfordern zeigt Bestaetigung", async ({ page }) => {
+    let body = null;
+    await page.route("**/auth/request-password-reset", (route) => {
+      body = route.request().postDataJSON();
+      route.fulfill({
+        status: 200,
+        headers: {
+          "access-control-allow-origin": "*",
+          "content-type": "application/json",
+        },
+        body: "{}",
+      });
+    });
+
+    await page.goto("/request-reset");
+    await page.getByPlaceholder("E-Mail").fill("user@example.com");
+    await page.getByRole("button", { name: /link senden/i }).click();
+
+    await expect(page.getByText(/wenn die e-mail existiert/i)).toBeVisible();
+    expect(body).toEqual({ email: "user@example.com" });
+  });
+
+  test("neues passwort: success und error message", async ({ page }) => {
+    await page.route("**/auth/reset-password", (route) => {
+      const ok = route.request().postDataJSON()?.token === "good";
+      route.fulfill({
+        status: ok ? 200 : 400,
+        headers: {
+          "access-control-allow-origin": "*",
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({}),
+      });
+    });
+
+    // Erfolgspfad
+    await page.goto("/reset-password?token=good");
+    await page.getByPlaceholder("Neues Passwort").fill("secret123");
+    await page.getByRole("button", { name: /speichern/i }).click();
+    await expect(page.getByText(/passwort gesetzt/i)).toBeVisible();
+
+    // Fehlerpfad
+    await page.goto("/reset-password?token=bad");
+    await page.getByPlaceholder("Neues Passwort").fill("secret456");
+    await page.getByRole("button", { name: /speichern/i }).click();
+    await expect(page.getByText(/ung/i)).toBeVisible();
+  });
+});

--- a/frontend/tests/e2e/landing.spec.js
+++ b/frontend/tests/e2e/landing.spec.js
@@ -1,18 +1,22 @@
-import { test, expect } from '@playwright/test';
+import { test, expect } from "@playwright/test";
 
-test.describe('Landing page', () => {
-  test('shows hero call-to-actions and feature copy', async ({ page }) => {
-    await page.goto('/');
-
-    await expect(page.getByRole('link', { name: 'Jetzt starten' })).toBeVisible();
-    await expect(page.getByRole('link', { name: 'Zur App' })).toBeVisible();
+test.describe("Landing page", () => {
+  test("shows hero call-to-actions and feature copy", async ({ page }) => {
+    await page.goto("/");
 
     await expect(
-      page.getByRole('heading', { name: /schneller suchen/i }),
+      page.getByRole("link", { name: "Jetzt starten" }),
+    ).toBeVisible();
+    await expect(page.getByRole("link", { name: "Zur App" })).toBeVisible();
+
+    await expect(
+      page.getByRole("heading", { name: /schneller suchen/i }),
     ).toBeVisible();
     await expect(
-      page.getByRole('heading', { name: /mer­ken mit nur einem klick/i }),
+      page.getByRole("heading", { name: /merken mit nur einem klick/i }),
     ).toBeVisible();
-    await expect(page.getByRole('heading', { name: /immer aktuell/i })).toBeVisible();
+    await expect(
+      page.getByRole("heading", { name: /immer aktuell/i }),
+    ).toBeVisible();
   });
 });

--- a/frontend/tests/e2e/landing.spec.js
+++ b/frontend/tests/e2e/landing.spec.js
@@ -1,0 +1,18 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Landing page', () => {
+  test('shows hero call-to-actions and feature copy', async ({ page }) => {
+    await page.goto('/');
+
+    await expect(page.getByRole('link', { name: 'Jetzt starten' })).toBeVisible();
+    await expect(page.getByRole('link', { name: 'Zur App' })).toBeVisible();
+
+    await expect(
+      page.getByRole('heading', { name: /schneller suchen/i }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole('heading', { name: /mer­ken mit nur einem klick/i }),
+    ).toBeVisible();
+    await expect(page.getByRole('heading', { name: /immer aktuell/i })).toBeVisible();
+  });
+});

--- a/frontend/tests/e2e/landing.spec.js
+++ b/frontend/tests/e2e/landing.spec.js
@@ -1,14 +1,21 @@
 import { test, expect } from "@playwright/test";
 
+// Smoke: Landing-CTAs sichtbar und korrekt verlinkt; drei Feature-Headings vorhanden.
 test.describe("Landing page", () => {
   test("shows hero call-to-actions and feature copy", async ({ page }) => {
     await page.goto("/");
 
-    await expect(
-      page.getByRole("link", { name: "Jetzt starten" }),
-    ).toBeVisible();
-    await expect(page.getByRole("link", { name: "Zur App" })).toBeVisible();
+    const startLink = page.getByRole("link", { name: "Jetzt starten" });
+    const appLink = page.getByRole("link", { name: "Zur App" });
 
+    // Haupt-CTAs: sichtbar und verlinken auf Register/App
+    await expect(startLink).toBeVisible();
+    await expect(startLink).toHaveAttribute("href", "/register");
+
+    await expect(appLink).toBeVisible();
+    await expect(appLink).toHaveAttribute("href", "/app");
+
+    // Drei Feature-Titel auf der Seite
     await expect(
       page.getByRole("heading", { name: /schneller suchen/i }),
     ).toBeVisible();
@@ -18,5 +25,8 @@ test.describe("Landing page", () => {
     await expect(
       page.getByRole("heading", { name: /immer aktuell/i }),
     ).toBeVisible();
+
+    // H3-Überschriften sollten genau dreimal vorhanden sein
+    await expect(page.getByRole("heading", { level: 3 })).toHaveCount(3);
   });
 });

--- a/frontend/tests/e2e/navigation.spec.js
+++ b/frontend/tests/e2e/navigation.spec.js
@@ -1,0 +1,102 @@
+import { test, expect } from "@playwright/test";
+
+// Dauerhaftes Fake-JWT mit gueltigem exp in ferner Zukunft,
+// damit initAutoLogout nicht die Tokens loescht.
+const TEST_ACCESS =
+  "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiIjo0MTAyNDQ0ODAwfQ.dummy";
+
+// Navigation: Sidebar-Routen wechseln korrekt; Logo führt zur Landing Page.
+test.use({
+  storageState: {
+    origins: [
+      {
+        origin: "http://localhost:5173",
+        localStorage: [
+          { name: "access", value: TEST_ACCESS },
+          { name: "refresh", value: "e2e-refresh" },
+          { name: "auth_email", value: "e2e@example.com" },
+        ],
+      },
+      {
+        origin: "http://127.0.0.1:5173",
+        localStorage: [
+          { name: "access", value: TEST_ACCESS },
+          { name: "refresh", value: "e2e-refresh" },
+          { name: "auth_email", value: "e2e@example.com" },
+        ],
+      },
+    ],
+  },
+});
+
+test.describe("Navigation & Routing", () => {
+  test.beforeEach(async ({ page }) => {
+    const ctx = page.context();
+
+    // Mocks VOR irgendeinem goto registrieren (auf Context-Ebene, damit auch Reloads abgefangen werden)
+    await ctx.route("**/auth/login", (route) =>
+      route.fulfill({
+        status: 200,
+        headers: {
+          "access-control-allow-origin": "*",
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({ access: TEST_ACCESS, refresh: "e2e-refresh" }),
+      }),
+    );
+    await ctx.route("**/jobsuchen", (route) =>
+      route.fulfill({
+        status: 200,
+        headers: {
+          "access-control-allow-origin": "*",
+          "content-type": "application/json",
+        },
+        body: "[]",
+      }),
+    );
+    await ctx.route("**/update_bookmark", (route) =>
+      route.fulfill({
+        status: 200,
+        headers: {
+          "access-control-allow-origin": "*",
+          "content-type": "application/json",
+        },
+        body: "{}",
+      }),
+    );
+
+    // Token direkt setzen, dann App laden (keine UI-Interaktion nötig)
+    await page.addInitScript(({ token }) => {
+      localStorage.setItem("access", token);
+      localStorage.setItem("refresh", "e2e-refresh");
+      localStorage.setItem("auth_email", "e2e@example.com");
+    }, { token: TEST_ACCESS });
+
+    await page.goto("/app");
+  });
+
+  test("sidebar buttons navigate between app sections", async ({ page }) => {
+    // Sidebar-Reiter springen durch die App-Abschnitte
+    await expect(page).toHaveURL(/\/app$/);
+
+    await page.getByRole("button", { name: "Lesezeichen" }).click();
+    await expect(page).toHaveURL(/\/bookmarked$/);
+
+    await page.getByRole("button", { name: /suchauftr/i }).click();
+    await expect(page).toHaveURL(/\/search_alerts$/);
+
+    // Browser-History funktioniert erwartungsgemäß
+    await page.goBack();
+    await expect(page).toHaveURL(/\/bookmarked$/);
+    await page.goForward();
+    await expect(page).toHaveURL(/\/search_alerts$/);
+  });
+
+  test("logo link führt zur Landing Page", async ({ page }) => {
+    await page.goto("/app");
+
+    // Logo im Header sollte immer auf Home verlinken
+    await page.getByRole("link", { name: "Night Crawler" }).click();
+    await expect(page).toHaveURL(/\/$/);
+  });
+});

--- a/frontend/tests/e2e/search.spec.js
+++ b/frontend/tests/e2e/search.spec.js
@@ -1,0 +1,129 @@
+import { test, expect } from "@playwright/test";
+
+// Vorbefüllter Storage-State: simuliert eingeloggten User für /app-Routen.
+// Dauerhaftes Fake-JWT mit gueltigem exp in ferner Zukunft,
+// damit initAutoLogout nicht die Tokens loescht.
+const TEST_ACCESS =
+  "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiIjo0MTAyNDQ0ODAwfQ.dummy";
+
+test.use({
+  storageState: {
+    origins: [
+      {
+        origin: "http://localhost:5173",
+        localStorage: [
+          { name: "access", value: TEST_ACCESS },
+          { name: "refresh", value: "e2e-refresh" },
+          { name: "auth_email", value: "e2e@example.com" },
+        ],
+      },
+      {
+        origin: "http://127.0.0.1:5173",
+        localStorage: [
+          { name: "access", value: TEST_ACCESS },
+          { name: "refresh", value: "e2e-refresh" },
+          { name: "auth_email", value: "e2e@example.com" },
+        ],
+      },
+    ],
+  },
+});
+
+// Jobsuche: Request-Body, Ergebnisliste, Bookmark-Toggle (alles gemockt).
+test.describe("Jobsuche & Bookmark", () => {
+  test.beforeEach(async ({ page }) => {
+    const ctx = page.context();
+
+    // Jobsuchen- und Bookmark-API stubben (Context-Ebene, greift auch bei Reloads)
+    const jobs = [
+      {
+        _id: "job-1",
+        title: "Fullstack Developer",
+        company: "Acme Inc",
+        link: "https://example.com/job-1",
+        bookmark: false,
+      },
+      {
+        _id: "job-2",
+        title: "Frontend Engineer",
+        company: "Globex",
+        link: "https://example.com/job-2",
+        bookmark: false,
+      },
+    ];
+
+    const searchBodies = [];
+    const bookmarkBodies = [];
+
+    await ctx.route("**/jobsuchen", (route) => {
+      const req = route.request();
+      if (req.method() === "POST") {
+        searchBodies.push(req.postDataJSON());
+        route.fulfill({
+          status: 200,
+          headers: {
+            "access-control-allow-origin": "*",
+            "content-type": "application/json",
+          },
+          body: JSON.stringify(jobs),
+        });
+      } else {
+        route.fulfill({
+          status: 200,
+          headers: {
+            "access-control-allow-origin": "*",
+            "content-type": "application/json",
+          },
+          body: "[]",
+        });
+      }
+    });
+
+    await ctx.route("**/update_bookmark", (route) => {
+      bookmarkBodies.push(route.request().postDataJSON());
+      route.fulfill({
+        status: 200,
+        headers: {
+          "access-control-allow-origin": "*",
+          "content-type": "application/json",
+        },
+        body: "{}",
+      });
+    });
+
+    await page.goto("/app");
+
+    // Eingaben: Keyword, Standort, Radius, dann Suche starten
+    await page.getByPlaceholder("Neuen Suchbegriff eingeben").fill("Node.js");
+    await page.getByRole("button", { name: /\+ Suchbegriff/i }).click();
+    await page.getByPlaceholder("Standort eingeben").fill("Berlin");
+    await page.locator("select#radius").selectOption("50");
+    await page.getByRole("button", { name: /jobs finden/i }).click();
+
+    // Ergebnisse erscheinen
+    await expect(page.getByText("Fullstack Developer")).toBeVisible();
+    await expect(page.getByText("Frontend Engineer")).toBeVisible();
+
+    // Request-Body prüfen
+    expect(searchBodies).toHaveLength(1);
+    expect(searchBodies[0]).toEqual({
+      keywords: ["Node.js"],
+      location: "Berlin",
+      radius: "50",
+    });
+
+    // Bookmark toggle: erst speichern, dann wieder entfernen
+    const firstBookmark = page
+      .getByRole("button", { name: /lesezeichen speichern/i })
+      .first();
+    await expect(firstBookmark).toHaveAttribute("aria-pressed", "false");
+    await firstBookmark.click();
+    await expect(firstBookmark).toHaveAttribute("aria-pressed", "true");
+
+    // Request für Bookmark wurde abgesetzt
+    expect(bookmarkBodies[0]).toEqual({
+      _id: "job-1",
+      bookmark: true,
+    });
+  });
+});


### PR DESCRIPTION
# Hinzufügen von e2e testing im frontend

## Motivation & Kontext

Prüfen, dass die Landing-Page die primären CTA-Links und Feature-Blöcke rendert.

Closes #[spontan]

---

## Änderungen

- [x] Neue Features
- [ ] Bugfixes
- [x] Dokumentation
- [ ] Refactoring

---

## Reproduktions- / Testschritte

1. Starte über npm run test:e2e oder über npm run test:e2e:headed (zum Debuggen)
2. Die `playwright.config.js` startet automatisch `npm run dev -- --host --port 5173`. Setze `E2E_BASE_URL`, wenn du einen bereits laufenden Server wiederverwenden möchtest, oder `E2E_PORT`, um den Port zu ändern.
3. Aktuelle Tests liegen unter `tests/e2e/`

---

## ENV / Secrets

- [ ] Relevante ENV-Variablen dokumentiert
- [ ] Azure App Settings geprüft
- [ ] GitHub Secrets aktualisiert (falls nötig)

---

## Checks

- [x] Linter lokal ausgeführt
- [x] Tests lokal bestanden
- [x] Security-Scan (Trivy) bei Docker-Änderungen durchgeführt
- [x] CI/CD Checks erfolgreich

---

## Reviewer Notes

Weitere test folgen.
